### PR TITLE
Clarify example and change route description data type

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,7 @@ Install and use via the gtfsdb source tree:
 4. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
    examples:
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip
-   - bin/gtfsdb-load --database_url postgresql://postgres@localhost:5432 --is_geospatial http://developer.trimet.org/schedule/gtfs.zip  
+   - bin/gtfsdb-load --database_url postgresql://postgres@localhost:5432/your_database --is_geospatial http://developer.trimet.org/schedule/gtfs.zip  
    NOTE: using the `is_geospatial` arg will take much longer to load...
 
 

--- a/gtfsdb/model/route.py
+++ b/gtfsdb/model/route.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 
 from sqlalchemy import Column
 from sqlalchemy.orm import deferred, relationship
-from sqlalchemy.types import Integer, String
+from sqlalchemy.types import Integer, String, Text
 from sqlalchemy.sql import func
 
 from gtfsdb import config
@@ -35,7 +35,7 @@ class Route(Base):
     agency_id = Column(String(255), index=True, nullable=True)
     route_short_name = Column(String(255))
     route_long_name = Column(String(255))
-    route_desc = Column(String(255))
+    route_desc = Column(Text)
     route_type = Column(Integer, index=True, nullable=False)
     route_url = Column(String(255))
     route_color = Column(String(6))


### PR DESCRIPTION
I made a small tweak to the README to clarify how to specify which database the data should be inserted into. Without specifying a database, the scripts run but do not actually put the data anywhere.

I was also getting an error when importing route descriptions because the field is of length 255, and descriptions can often be quite verbose.

Let me know what you think! Thanks for creating such a great package.