### PR TITLE
Stop using booleans & cli spam fix

### DIFF
--- a/gtfsdb/model/calendar.py
+++ b/gtfsdb/model/calendar.py
@@ -5,7 +5,7 @@ import time
 from sqlalchemy import Column, Index
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
-from sqlalchemy.types import Boolean, Date, Integer, String
+from sqlalchemy.types import Date, Integer, String
 
 from gtfsdb import config
 from gtfsdb.model.base import Base
@@ -25,13 +25,13 @@ class Calendar(Base):
     __table_args__ = (Index('calendar_ix1', 'start_date', 'end_date'),)
 
     service_id = Column(String(255), primary_key=True, index=True, nullable=False)
-    monday = Column(Boolean, nullable=False)
-    tuesday = Column(Boolean, nullable=False)
-    wednesday = Column(Boolean, nullable=False)
-    thursday = Column(Boolean, nullable=False)
-    friday = Column(Boolean, nullable=False)
-    saturday = Column(Boolean, nullable=False)
-    sunday = Column(Boolean, nullable=False)
+    monday = Column(Integer, nullable=False)
+    tuesday = Column(Integer, nullable=False)
+    wednesday = Column(Integer, nullable=False)
+    thursday = Column(Integer, nullable=False)
+    friday = Column(Integer, nullable=False)
+    saturday = Column(Integer, nullable=False)
+    sunday = Column(Integer, nullable=False)
     start_date = Column(Date, nullable=False)
     end_date = Column(Date, nullable=False)
     service_name = Column(String(255))  # Trillium extension, a human-readable name for the calendar.

--- a/gtfsdb/model/route_stop.py
+++ b/gtfsdb/model/route_stop.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import datetime
 import logging
 import sys
@@ -277,8 +275,6 @@ class RouteStop(Base):
                                         unique_stops.insert(last_pos, st.stop_id)
                                     else:
                                         unique_stops.append(st.stop_id)
-
-                print(unique_stops)
 
                 # PART B: add records to the database ...
                 if len(unique_stops) > 0:

--- a/gtfsdb/model/stop_time.py
+++ b/gtfsdb/model/stop_time.py
@@ -6,7 +6,7 @@ from gtfsdb.model.base import Base
 from sqlalchemy import Column
 from sqlalchemy.orm import joinedload_all, relationship
 from sqlalchemy.sql.expression import func
-from sqlalchemy.types import Boolean, Integer, Numeric, String
+from sqlalchemy.types import Integer, Numeric, String
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class StopTime(Base):
     pickup_type = Column(Integer, default=0)
     drop_off_type = Column(Integer, default=0)
     shape_dist_traveled = Column(Numeric(20, 10))
-    timepoint = Column(Boolean, index=True, default=False)
+    timepoint = Column(Integer)
 
     stop = relationship(
         'Stop',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ extras_require = dict(
 
 install_requires = [
     'geoalchemy2>=0.2.4',
-    'sqlalchemy<1.2',     # v1.2 doesn't allow Boolean values of '0' and '1', so this the simple workaround
-    'zope.sqlalchemy',    # not used here...but required for pyaramid apps (and pinning sqlalchemy above means this needs to be here)
+    'sqlalchemy',
+    'zope.sqlalchemy' # not used here, but required for pyramid apps
 ]
 
 if sys.version_info[:2] <= (2, 6):


### PR DESCRIPTION
Treating those as booleans ends up inserting wrong values to the db.
Also allows to remove the sqlalchemy version limit.

Fixes #20 + cli spam fix (too much unneeded printing is going on)