### PR TITLE
remove Boolean from sqlalchemy orm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,25 +15,27 @@ Supported Databases
 - MySQL  - tested
 - SQLite - tested
 
+
 GTFS (General Transit Feed Specification) Database
 ==================================================
 
 Python code that will load GTFS data into a relational database, and SQLAlchemy ORM bindings to the GTFS tables in the gtfsdb. 
+The gtfsdb project's focus is on making GTFS data available in a programmatic context for software developers. The need for the
+gtfsdb project comes from the fact that a lot of developers start out a GTFS-related effort by first building some amount of code
+to read GTFS data (whether that's an in-memory loader, a database loader, etc...);  GTFSDB can hopefully reduce the need for such
+drudgery, and give developers a starting point beyond the first step of dealing with GTFS in .csv file format.
 
-The gtfsdb project's focus is on making GTFS data available in a programmatic context for software developers. The need for the gtfsdb project comes from the fact that a lot of developers start out a GTFS-related effort by first building some amount of code to read GTFS data (whether that's an in-memory loader, a database loader, etc...);  GTFSDB can hopefully reduce the need for such drudgery, and give developers a starting point beyond the first step of dealing with GTFS in .csv file format.
-
-Available on pypi: https://pypi.python.org/pypi/gtfsdb
+(Pretty old stuff) available on pypi: https://pypi.python.org/pypi/gtfsdb
 
 
 Install and use via the gtfsdb source tree:
 ==========================================
 
-0. Install Python 2.7, easy_install (https://pypi.python.org/pypi/setuptools) and zc.buildout (https://pypi.python.org/pypi/zc.buildout/2.5.2) on your system...
+1. Install Python 2.7 (or 3.x), easy_install (https://pypi.python.org/pypi/setuptools) and zc.buildout (https://pypi.python.org/pypi/zc.buildout/2.5.2) on your system...
 1. git clone https://github.com/OpenTransitTools/gtfsdb.git
-2. cd gtfsdb
-3. buildout install prod
-   NOTE: if you're using postgres, do a 'buildout install prod postgresql'
-4. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
+1. cd gtfsdb
+1. buildout install prod -- NOTE: if you're using postgres, do a 'buildout install prod postgresql'
+1. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
    examples:
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db gtfsdb/tests/large-sample-feed.zip
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip
@@ -51,7 +53,7 @@ If you are on windows, you most likely have to find and install a pre-compiled v
 
 
 Install Steps (on Windows):
----------------------------
+===========================
     0. Have a db - docs and examples assume Postgres/PostGIS installed
        http://www.postgresql.org/download/windows
        http://postgis.refractions.net/download/windows/
@@ -72,17 +74,9 @@ Install Steps (on Windows):
 
     7. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
 
-NEWS:
------
-|
-NOTE: May 2016 ... for folks with legacy gtfsdb databases, two new columns were recently added. These two statements will keep you running against the new code w/out having to fully recreate your database from scratch:
- - ALTER TABLE routes ADD COLUMN min_headway_minutes integer;
- - ALTER TABLE calendar ADD COLUMN service_desc character varying(255); 
-|
-
 
 Example Query:
---------------
+==============
 
 -- get first stop time of each trip for route_id 1
 select *

--- a/gtfsdb/model/calendar.py
+++ b/gtfsdb/model/calendar.py
@@ -5,7 +5,7 @@ import time
 from sqlalchemy import Column, Index
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
-from sqlalchemy.types import Boolean, Date, Integer, String
+from sqlalchemy.types import Date, SmallInteger, Integer, String
 
 from gtfsdb import config
 from gtfsdb.model.base import Base
@@ -25,13 +25,13 @@ class Calendar(Base):
     __table_args__ = (Index('calendar_ix1', 'start_date', 'end_date'),)
 
     service_id = Column(String(255), primary_key=True, index=True, nullable=False)
-    monday = Column(Boolean, nullable=False)
-    tuesday = Column(Boolean, nullable=False)
-    wednesday = Column(Boolean, nullable=False)
-    thursday = Column(Boolean, nullable=False)
-    friday = Column(Boolean, nullable=False)
-    saturday = Column(Boolean, nullable=False)
-    sunday = Column(Boolean, nullable=False)
+    monday = Column(SmallInteger, nullable=False)
+    tuesday = Column(SmallInteger, nullable=False)
+    wednesday = Column(SmallInteger, nullable=False)
+    thursday = Column(SmallInteger, nullable=False)
+    friday = Column(SmallInteger, nullable=False)
+    saturday = Column(SmallInteger, nullable=False)
+    sunday = Column(SmallInteger, nullable=False)
     start_date = Column(Date, nullable=False)
     end_date = Column(Date, nullable=False)
     service_name = Column(String(255))  # Trillium extension, a human-readable name for the calendar.

--- a/gtfsdb/model/stop_time.py
+++ b/gtfsdb/model/stop_time.py
@@ -6,7 +6,7 @@ from gtfsdb.model.base import Base
 from sqlalchemy import Column
 from sqlalchemy.orm import joinedload_all, relationship
 from sqlalchemy.sql.expression import func
-from sqlalchemy.types import Boolean, Integer, Numeric, String
+from sqlalchemy.types import SmallInteger, Integer, Numeric, String
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class StopTime(Base):
     pickup_type = Column(Integer, default=0)
     drop_off_type = Column(Integer, default=0)
     shape_dist_traveled = Column(Numeric(20, 10))
-    timepoint = Column(Boolean, index=True, default=False)
+    timepoint = Column(SmallInteger, index=True, default=0)
 
     stop = relationship(
         'Stop',
@@ -42,8 +42,9 @@ class StopTime(Base):
 
     def __init__(self, *args, **kwargs):
         super(StopTime, self).__init__(*args, **kwargs)
-        if 'timepoint' not in kwargs:
-            self.timepoint = 'arrival_time' in kwargs
+        if 'timepoint' not in kwargs:      # this logic is the int() equal of what was after changing this to SmallInt,
+            if 'arrival_time' in kwargs:   # but I'm wondering if this is now going to set all stop times to timepoint=1=True ???
+                self.timepoint = 1
 
     def get_headsign(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -14,18 +14,13 @@ extras_require = dict(
 )
 
 install_requires = [
-    'geoalchemy2>=0.2.4',
-    'sqlalchemy<1.2',     # v1.2 doesn't allow Boolean values of '0' and '1', so this the simple workaround
-    'zope.sqlalchemy',    # not used here...but required for pyaramid apps (and pinning sqlalchemy above means this needs to be here)
+    'geoalchemy2',
+    'sqlalchemy'
 ]
-
-if sys.version_info[:2] <= (2, 6):
-    install_requires.append('argparse>=1.2.1')
-    extras_require['dev'].append('unittest2')
 
 setup(
     name='gtfsdb',
-    version='0.5.0',
+    version='0.4.2',
     description='GTFS Database',
     long_description=open('README.rst').read(),
     keywords='GTFS',


### PR DESCRIPTION
closes #20 ... removes Boolean and uses SmallInt so that 1 and 0 (used in GTFS) can be loaded into the db via SQLAlchemy, etc...

Thank you to @BakuCity and @celron ... I appreciate your PRs  (sorry I had to do this myself ... competing PRs for the same fix left me with the dilemma that seemed I should just add a 3rd)
