### PR TITLE
Update scripts.py

### DIFF
--- a/gtfsdb/scripts.py
+++ b/gtfsdb/scripts.py
@@ -21,7 +21,7 @@ def get_args():
         prog='gtfsdb-load',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('file', help='URL or local path to GTFS zip FILE')
-    parser.add_argument('--batch_size', '-b', default=config.DEFAULT_BATCH_SIZE,
+    parser.add_argument('--batch_size', '-b', type=int, default=config.DEFAULT_BATCH_SIZE,
                         help='BATCH SIZE to use for memory management')
     parser.add_argument('--database_url', '-d', default=config.DEFAULT_DATABASE_URL,
                         help='DATABASE URL with appropriate privileges')


### PR DESCRIPTION
type=int for the command line argument --batch_size

else i have this error:

  File "N:\prg\dep\bgeo\gtfsdb_venv2018\gtfsdb-git-131118\bin\gtfsdb-load-script.py", line 13, in <module>
    sys.exit(gtfsdb.scripts.gtfsdb_load())
  File "n:\prg\dep\bgeo\gtfsdb_venv2018\gtfsdb-git-131118\gtfsdb\scripts.py", line 12, in gtfsdb_load
    database_load(args.file, **kwargs)
  File "n:\prg\dep\bgeo\gtfsdb_venv2018\gtfsdb-git-131118\gtfsdb\api.py", line 21, in database_load
    gtfs.load(db, **kwargs)
  File "n:\prg\dep\bgeo\gtfsdb_venv2018\gtfsdb-git-131118\gtfsdb\model\gtfs.py", line 40, in load
    db.load_tables(**kwargs)
  File "n:\prg\dep\bgeo\gtfsdb_venv2018\gtfsdb-git-131118\gtfsdb\model\db.py", line 61, in load_tables
    cls.load(self, **kwargs)
  File "n:\prg\dep\bgeo\gtfsdb_venv2018\gtfsdb-git-131118\gtfsdb\model\base.py", line 179, in load
    if i >= batch_size:
TypeError: '>=' not supported between instances of 'int' and 'str'