### PR TITLE
Psycopg2 binary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,17 +33,17 @@ Install and use via the gtfsdb source tree:
 
 1. Install Python 3.x (or 2.7)
 
-1.  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
+2.  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
 
-1. (if a postgres user, then `pip install psycopg2-binary`)
+3. (if a postgres user, then `pip install psycopg2-binary`)
 
-1. git clone https://github.com/OpenTransitTools/gtfsdb.git
+4. git clone https://github.com/OpenTransitTools/gtfsdb.git
 
-1. cd gtfsdb
+5. cd gtfsdb
 
-1. buildout install prod -- NOTE: if you're using postgres, do a 'buildout install prod postgresql'
+6. buildout install prod -- NOTE: if you're using postgres, do a 'buildout install prod postgresql'
 
-1. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
+7. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
 
    examples:
    
@@ -53,7 +53,7 @@ Install and use via the gtfsdb source tree:
 
    NOTE: adding the `is_geospatial` cmdline flag, when paired with a spatial-database ala PostGIS (e.g., is_spatial is meaningless with sqllite), will take longer to load...but will create geometry columns for both rendering and calculating nearest distances, etc...
 
-1. view db ( example: https://sqliteonline.com )
+8. view db ( example: https://sqliteonline.com )
 
 The best way to get gtfsbd up and running is via the 'zc.buildout' tool.  Highly recommended to first install
 buildout (e.g., pip install zc.buildout) before doing much of anything else.
@@ -64,24 +64,24 @@ will relieve gtfsdb from re-installing locally as part of the build.  And if aft
 
 Install Steps (on Windows):
 ===========================
-1. Recommend having a 'real' db installed - docs and examples assume Postgres/PostGIS installed
+0. Recommend having a 'real' db installed - docs and examples assume Postgres/PostGIS installed
    http://www.postgresql.org/download/windows
    http://postgis.refractions.net/download/windows/
 
 1. Install Python 3.x https://www.python.org/downloads/release/python-391 or Python2.7 https://www.python.org/downloads/release/python-2718
 
-1. `pip install zc.buildout`
+2. `pip install zc.buildout`
 
-1. `git clone https://github.com/OpenTransitTools/gtfsdb.git`
+3. `git clone https://github.com/OpenTransitTools/gtfsdb.git`
 
-1. `cd gtfsdb`
+4. `cd gtfsdb`
 
-1. `buildout`
+5. `buildout`
 
-1. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
+6. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
    example: `bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip`
 
-1. view db ( example: https://sqliteonline.com )
+7. view db ( example: https://sqliteonline.com )
 
 Example Query:
 ==============

--- a/README.rst
+++ b/README.rst
@@ -25,17 +25,17 @@ gtfsdb project comes from the fact that a lot of developers start out a GTFS-rel
 to read GTFS data (whether that's an in-memory loader, a database loader, etc...);  GTFSDB can hopefully reduce the need for such
 drudgery, and give developers a starting point beyond the first step of dealing with GTFS in .csv file format.
 
-(Pretty old stuff) available on pypi: https://pypi.python.org/pypi/gtfsdb
+(Slightly out-of-date version) available on pypi: https://pypi.python.org/pypi/gtfsdb
 
 
-Install and use via the gtfsdb source tree:
+Install from source via github (if you want the latest code) :
 ==========================================
 
 1. Install Python 3.x https://www.python.org/downloads/ (code also runs on 2.7 if you are stuck on that version)
 
 2.  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
 
-3. (if a postgres user, then `pip install psycopg2-binary`)
+3. (`pip install psycopg2-binary` if a postgres user)
 
 4. git clone https://github.com/OpenTransitTools/gtfsdb.git
 
@@ -59,29 +59,9 @@ The best way to get gtfsbd up and running is via the 'zc.buildout' tool.  Highly
 buildout (e.g., pip install zc.buildout) before doing much of anything else.
 
 Postgres users, gtfsdb requires the psycopg2-binary database driver.  Installing that via `pip install psychopg2-binary`
-will relieve gtfsdb from re-installing locally as part of the build.  And if after the fact, you see exceptions saying
-"ImportError: No module named psycopg2", then `pip install psychopg2-binary` should fix that...
+will relieve gtfsdb from re-installing locally as part of the build.  And if after the fact, you see *exceptions* mentioning
+**"ImportError: No module named psycopg2"**, then 'pip install psychopg2-binary' should fix that up quick...
 
-Install Steps (on Windows):
-===========================
-0. Recommend having a 'real' db installed - docs and examples assume Postgres/PostGIS installed
-   http://www.postgresql.org/download/windows
-   http://postgis.refractions.net/download/windows/
-
-1. Install Python 3.x https://www.python.org/downloads/  (will run on Python 2.7 if need be)
-
-2. `pip install zc.buildout`
-
-3. `git clone https://github.com/OpenTransitTools/gtfsdb.git`
-
-4. `cd gtfsdb`
-
-5. `buildout`
-
-6. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
-   example: `bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip`
-
-7. view db ( example: https://sqliteonline.com )
 
 Example Query:
 ==============

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ drudgery, and give developers a starting point beyond the first step of dealing 
 Install and use via the gtfsdb source tree:
 ==========================================
 
-1. Install Python 2.7 (or 3.x), easy_install (https://pypi.python.org/pypi/setuptools) and zc.buildout (https://pypi.python.org/pypi/zc.buildout/2.5.2) on your system...
+1. Install Python 3.x (or 2.7)
+1  pip install zc.buildout - https://pypi.org/project/zc.buildout
 1. git clone https://github.com/OpenTransitTools/gtfsdb.git
 1. cd gtfsdb
 1. buildout install prod -- NOTE: if you're using postgres, do a 'buildout install prod postgresql'
@@ -41,39 +42,34 @@ Install and use via the gtfsdb source tree:
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip
    - bin/gtfsdb-load --database_url postgresql://postgres@localhost:5432 --is_geospatial http://developer.trimet.org/schedule/gtfs.zip  
    NOTE: using the `is_geospatial` arg will take much longer to load...
+1. view db ( example: https://sqliteonline.com )
 
+The best way to get gtfsbd up and running is via the 'zc.buildout' tool.  Highly recommended to first install
+buildout (e.g., pip install zc.buildout) before doing anything else.
 
-The best way to get gtfsbd up and running is via the python 'buildout' and 'easy_install' tools.
-Highly recommended to first install easy_install (setup tools) and buildout (e.g., easy_install zc.buildout)
-before doing anything else.
-
-Postgres users, gtfsdb requires the psycopg2 database driver. If you are on linux / mac, buildout will
-install the necessary dependencies (or re-use whatever you have in your system site-lib).
-If you are on windows, you most likely have to find and install a pre-compiled version (see below).
-
+Postgres users, gtfsdb requires the psycopg2-binary database driver.  Installing that via `pip install psychopg2-binary`
+will relieve gtfsdb from re-installing locally as part of the build.
 
 Install Steps (on Windows):
 ===========================
-    0. Have a db - docs and examples assume Postgres/PostGIS installed
-       http://www.postgresql.org/download/windows
-       http://postgis.refractions.net/download/windows/
+1. Recommend having a 'real' db installed - docs and examples assume Postgres/PostGIS installed
+   http://www.postgresql.org/download/windows
+   http://postgis.refractions.net/download/windows/
 
-    1. Python2.7 - http://www.python.org/download/releases/2.7.6/ (python-2.7.6.msi)
-       NOTE: see this for setting env variables correctly: https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables
+1. Install Python 3.x https://www.python.org/downloads/release/python-391 or Python2.7 https://www.python.org/downloads/release/python-2718
 
-    2a. Install Setup Tools (easy_install) https://pypi.python.org/pypi/setuptools#windows-8-powershell
-    2b. easy_install zc.buildout
+1. `pip install zc.buildout`
 
-    3. Install Psygopg2 (from binary):  http://www.stickpeople.com/projects/python/win-psycopg/
+1. `git clone https://github.com/OpenTransitTools/gtfsdb.git`
 
-    4. Check out gtfsdb from trunk with Git - see: git clone https://github.com/OpenTransitTools/gtfsdb.git
+1. `cd gtfsdb`
 
-    5. cd top level of gtfsdb tree
-    
-    6. buildout install prod
+1. `buildout`
 
-    7. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
+1. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
+   example: `bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip`
 
+1. view db ( example: https://sqliteonline.com )
 
 Example Query:
 ==============
@@ -84,7 +80,6 @@ from trips t, stop_times st
 where t.route_id = '1'
 and t.trip_id = st.trip_id
 and st.stop_sequence = 1
-
 
 -- get agency name and number of routes 
 select a.agency_name, a.agency_id, count(r.route_id)

--- a/README.rst
+++ b/README.rst
@@ -67,13 +67,15 @@ Example Query:
 ==============
 
 -- get first stop time of each trip for route_id 1
+
 select *
 from trips t, stop_times st
 where t.route_id = '1'
 and t.trip_id = st.trip_id
 and st.stop_sequence = 1
 
--- get agency name and number of routes 
+-- get agency name and number of routes
+
 select a.agency_name, a.agency_id, count(r.route_id)
 from routes r, agency a
 where r.agency_id = a.agency_id

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ drudgery, and give developers a starting point beyond the first step of dealing 
 Install and use via the gtfsdb source tree:
 ==========================================
 
-1. Install Python 3.x (or 2.7)
+1. Install Python 3.x https://www.python.org/downloads/ (code also runs on 2.7 if you are stuck on that version)
 
 2.  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
 
@@ -68,7 +68,7 @@ Install Steps (on Windows):
    http://www.postgresql.org/download/windows
    http://postgis.refractions.net/download/windows/
 
-1. Install Python 3.x https://www.python.org/downloads/release/python-391 or Python2.7 https://www.python.org/downloads/release/python-2718
+1. Install Python 3.x https://www.python.org/downloads/  (will run on Python 2.7 if need be)
 
 2. `pip install zc.buildout`
 

--- a/README.rst
+++ b/README.rst
@@ -32,18 +32,27 @@ Install and use via the gtfsdb source tree:
 ==========================================
 
 1. Install Python 3.x (or 2.7)
-1  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
+
+1.  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
+
 1. (if a postgres user, then `pip install psycopg2-binary`)
+
 1. git clone https://github.com/OpenTransitTools/gtfsdb.git
+
 1. cd gtfsdb
+
 1. buildout install prod -- NOTE: if you're using postgres, do a 'buildout install prod postgresql'
+
 1. bin/gtfsdb-load --database_url <db url>  <gtfs file | url>
+
    examples:
+   
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db gtfsdb/tests/large-sample-feed.zip
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip
    - bin/gtfsdb-load --database_url postgresql://postgres@localhost:5432 --is_geospatial http://developer.trimet.org/schedule/gtfs.zip  
-   NOTE: adding the `is_geospatial` cmdline flag, when paired with a spatial-database ala PostGIS (e.g., is_spatial is meaningless with sqllite),
-         will take longer to load...but will create geometry columns for both rendering and calculating nearest distances, etc...
+
+   NOTE: adding the `is_geospatial` cmdline flag, when paired with a spatial-database ala PostGIS (e.g., is_spatial is meaningless with sqllite), will take longer to load...but will create geometry columns for both rendering and calculating nearest distances, etc...
+
 1. view db ( example: https://sqliteonline.com )
 
 The best way to get gtfsbd up and running is via the 'zc.buildout' tool.  Highly recommended to first install

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,8 @@ Install and use via the gtfsdb source tree:
 ==========================================
 
 1. Install Python 3.x (or 2.7)
-1  pip install zc.buildout - https://pypi.org/project/zc.buildout
+1  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
+1. (if a postgres user, then `pip install psycopg2-binary`)
 1. git clone https://github.com/OpenTransitTools/gtfsdb.git
 1. cd gtfsdb
 1. buildout install prod -- NOTE: if you're using postgres, do a 'buildout install prod postgresql'
@@ -41,14 +42,16 @@ Install and use via the gtfsdb source tree:
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db gtfsdb/tests/large-sample-feed.zip
    - bin/gtfsdb-load --database_url sqlite:///gtfs.db http://developer.trimet.org/schedule/gtfs.zip
    - bin/gtfsdb-load --database_url postgresql://postgres@localhost:5432 --is_geospatial http://developer.trimet.org/schedule/gtfs.zip  
-   NOTE: using the `is_geospatial` arg will take much longer to load...
+   NOTE: adding the `is_geospatial` cmdline flag, when paired with a spatial-database ala PostGIS (e.g., is_spatial is meaningless with sqllite),
+         will take longer to load...but will create geometry columns for both rendering and calculating nearest distances, etc...
 1. view db ( example: https://sqliteonline.com )
 
 The best way to get gtfsbd up and running is via the 'zc.buildout' tool.  Highly recommended to first install
-buildout (e.g., pip install zc.buildout) before doing anything else.
+buildout (e.g., pip install zc.buildout) before doing much of anything else.
 
 Postgres users, gtfsdb requires the psycopg2-binary database driver.  Installing that via `pip install psychopg2-binary`
-will relieve gtfsdb from re-installing locally as part of the build.
+will relieve gtfsdb from re-installing locally as part of the build.  And if after the fact, you see exceptions saying
+"ImportError: No module named psycopg2", then `pip install psychopg2-binary` should fix that...
 
 Install Steps (on Windows):
 ===========================

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Install from source via github (if you want the latest code) :
 
 2.  `pip install zc.buildout` - https://pypi.org/project/zc.buildout
 
-3. (`pip install psycopg2-binary` if a postgres user)
+3. (optinal step for **postgres users**: 'pip install psycopg2-binary')
 
 4. git clone https://github.com/OpenTransitTools/gtfsdb.git
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,7 +6,7 @@ develop = .
 app-egg-name = gtfsdb
 newest = false
 include-site-packages = true
-allowed-eggs-from-site-packages = psycopg2 Setuptools zc.buildout
+allowed-eggs-from-site-packages = psycopg2-binary Setuptools zc.buildout
 prefer-final = true
 
 [dev]

--- a/gtfsdb/model/db.py
+++ b/gtfsdb/model/db.py
@@ -132,9 +132,6 @@ class Database(object):
     def url(self, val):
         self._url = val
         self.engine = create_engine(val)
-        if self.is_sqlite:
-            import sqlite3
-            sqlite3.register_adapter(str, lambda s: s.decode('utf8'))
         session_factory = sessionmaker(self.engine)
         self.session = scoped_session(session_factory)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 
 oracle_extras = ['cx_oracle>=5.1']
-postgresql_extras = ['psycopg2>=2.4.2']
+postgresql_extras = ['psycopg2-binary']
 # dev_extras = oracle_extras + postgresql_extras
 dev_extras = []
 
@@ -16,7 +16,6 @@ extras_require = dict(
 install_requires = [
     'geoalchemy2',
     'sqlalchemy',
-    'psycopg2',
 ]
 
 setup(

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,24 +1,25 @@
 [versions]
 
-zc.recipe.egg = 2.0.7
-zc.recipe.testrunner = 2.0.0
 
-# Required by:
-# zope.testrunner==4.9.2
-zope.exceptions = 4.3
 
-# Required by:
-# zope.testrunner==4.9.2
-zope.interface = 4.6.0
-
-# Required by:
-# zc.recipe.testrunner==2.0.0
-zope.testrunner = 4.9.2
-
-# Added by buildout at 2020-12-24 11:11:11.111
+# Added by buildout at 2021-01-20 16:43:53.979741
 GeoAlchemy2 = 0.8.4
 SQLAlchemy = 1.3.22
+zc.recipe.egg = 2.0.7
+zc.recipe.testrunner = 2.2
 
 # Required by:
-# gtfsdb==0.5.0
-psycopg2 = 2.8.6
+# zope.testrunner==5.2
+six = 1.15.0
+
+# Required by:
+# zope.testrunner==5.2
+zope.exceptions = 4.4
+
+# Required by:
+# zope.testrunner==5.2
+zope.interface = 5.2.0
+
+# Required by:
+# zc.recipe.testrunner==2.2
+zope.testrunner = 5.2


### PR DESCRIPTION
switch to the postgres-binary, which makes the code a lot more portable across environments
tested on mac, win, linux with py 3.x (and linux 2.7)