### PR TITLE
Ignore empty stop times, post-process trips in batches

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,0 +1,1 @@
+```CREATE DATABASE mbta TEMPLATE template_postgis;```

--- a/gtfsdb/model/block.py
+++ b/gtfsdb/model/block.py
@@ -92,7 +92,7 @@ class Block(Base):
         if stop_id is None:
             stop_id = self.end_stop_id
 
-        if self.next_trip and self.next_trip.start_stop.stop_id == stop_id:
+        if self.next_trip and self.next_trip.start_stop and self.next_trip.start_stop.stop_id == stop_id:
             # import pdb; pdb.set_trace()
             ret_val = True
         return ret_val
@@ -153,6 +153,25 @@ class Block(Base):
 
             # step 4: create block objects
             for j, k in enumerate(sorted_blocks):
+                # check for missing start or end stops separately
+                start_stop_id = None
+                end_stop_id = None
+
+                if k.start_stop is None:
+                    log.warning('Trip {0} has missing start_stop'.format(k.trip_id))
+                else:
+                    start_stop_id = k.start_stop.stop_id
+
+                if k.end_stop is None:
+                    log.warning('Trip {0} has missing end_stop'.format(k.trip_id))
+                else:
+                    end_stop_id = k.end_stop.stop_id
+
+                # skip only if both are missing
+                if start_stop_id is None and end_stop_id is None:
+                    log.warning('Trip {0} has missing both start_stop and end_stop, skipping block creation'.format(k.trip_id))
+                    continue
+
                 prev = None
                 next = None
                 if j > 0:
@@ -166,8 +185,8 @@ class Block(Base):
                     trip_id=k.trip_id,
                     prev_trip_id=prev,
                     next_trip_id=next,
-                    start_stop_id=k.start_stop.stop_id,
-                    end_stop_id=k.end_stop.stop_id
+                    start_stop_id=start_stop_id,
+                    end_stop_id=end_stop_id
                 )
                 db.session.add(block)
 

--- a/gtfsdb/model/trip.py
+++ b/gtfsdb/model/trip.py
@@ -1,8 +1,10 @@
 import logging
 
+import psutil
+
 from gtfsdb import config
 from gtfsdb.model.base import Base
-from sqlalchemy import Column
+from sqlalchemy import Column, func
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Integer, String
 
@@ -61,11 +63,53 @@ class Trip(Base):
 
     @classmethod
     def post_process(cls, db, **kwargs):
-        trips = db.session.query(Trip).all()
-        for t in trips:
-            if not t.is_valid:
-                log.warning("invalid trip: {0} only has {1} stop_time record (i.e., maybe the stops are coded as "
-                  "non-public, and thus their stop time records didn't make it into the gtfs)".format(t.trip_id, t.trip_len))
+        from gtfsdb.model.stop_time import StopTime
+
+        batch_size = kwargs.get('batch_size', config.DEFAULT_BATCH_SIZE)
+        log.info("Trip.post_process: validating trips with batch size {}".format(batch_size))
+
+        # Use SQL aggregation to find invalid trips (those with < 2 stop_times) efficiently
+        # This avoids loading all trip and stop_time data into memory
+        subquery = (
+            db.session.query(
+                StopTime.trip_id,
+                func.count(StopTime.stop_sequence).label('stop_count')
+            )
+            .group_by(StopTime.trip_id)
+            .having(func.count(StopTime.stop_sequence) < 2)
+            .subquery()
+        )
+
+        # Get invalid trip IDs in batches
+        invalid_trips_query = (
+            db.session.query(Trip.trip_id)
+            .join(subquery, Trip.trip_id == subquery.c.trip_id)
+        )
+
+        # Process in batches to avoid memory issues
+        offset = 0
+        while True:
+            batch = invalid_trips_query.limit(batch_size).offset(offset).all()
+            if not batch:
+                break
+
+            for trip_row in batch:
+                # Get stop count for this specific trip
+                stop_count = db.session.query(func.count(StopTime.stop_sequence)).filter(
+                    StopTime.trip_id == trip_row.trip_id
+                ).scalar()
+
+                log.warning(
+                    "invalid trip: {0} only has {1} stop_time record (i.e., maybe the stops are coded as "
+                    "non-public, and thus their stop time records didn't make it into the gtfs)".format(
+                        trip_row.trip_id, stop_count
+                    )
+                )
+
+            offset += batch_size
+
+            # Clear session to free memory
+            db.session.expunge_all()
 
     @classmethod
     def query_trip(cls, session, trip_id, schema=None):

--- a/gtfsdb/scripts.py
+++ b/gtfsdb/scripts.py
@@ -126,3 +126,8 @@ def db_connect_tester():
     for st in stop_times:
         print(st.get_direction_name())
         break
+
+
+# args: https://cdn.mbta.com/MBTA_GTFS.zip -d postgresql+psycopg2://ott:ott@10.5.0.2/mbta -np -p --tables stop_times
+if __name__ == '__main__':
+    gtfsdb_load()


### PR DESCRIPTION
I encountered some issues while trying to process/post-process the MBTA GTFS feeds, which is quite a large dataset. The fixes ended up being the following:

- Handle incomplete stop time GTFS data in block.py by identifying empty values before attempting to process them
- Post-process trip data in trip.py in batches rather than loading everything from SQL at once in order to avoid memory depletion issues

Note: fixes generated using Claude AI, then reviewed and tested by myself, an actual human.

Both of these fixes may need to be incorporated into other parts of the project for more complete error handling, but this was the MVP to get my analysis off the ground.